### PR TITLE
feat: adding darwin client installation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -119,7 +119,7 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 - ~~**Linux client(Debian, RedHat and Arch base)**~~
 - ~~**Terraform to deploy server on AWS**~~
 - ~~**Mobile client**~~
-- **Mac client**
+- __**Mac client**__
 - **Add other cloud providers**
 
 ## Author

--- a/ansible/roles/client_install/tasks/main.yaml
+++ b/ansible/roles/client_install/tasks/main.yaml
@@ -20,7 +20,7 @@
     state: present
   with_items:
   - qrencode
-  when: ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat" and mobile | bool
+  when: ansible_facts['os_family'] == "Debian" or ansible_facts['os_family'] == "RedHat" and mobile |bool
 
 - name: Installing Wireguard client
   community.general.pacman:
@@ -34,6 +34,20 @@
     state: present
   when: ansible_facts['os_family'] == "Arch Linux" and  mobile |bool
 
+- name: Installing Wireguard client
+  community.general.homebrew:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+  - wireguard-tools
+  when: ansible_facts['os_family'] == "Darwin"
+
+- name: Installing qrencode
+  community.general.homebrew:
+    name: qrencode
+    state: la test
+  when: ansible_facts['os_family'] == "Darwin" and mobile |bool
+  
 - name: Create PrivateKey
   shell: |
     wg genkey

--- a/ansible/roles/client_install/tasks/main.yaml
+++ b/ansible/roles/client_install/tasks/main.yaml
@@ -45,7 +45,7 @@
 - name: Installing qrencode
   community.general.homebrew:
     name: qrencode
-    state: la test
+    state: latest
   when: ansible_facts['os_family'] == "Darwin" and mobile |bool
   
 - name: Create PrivateKey


### PR DESCRIPTION
To contribute with mac users, add Ansible tasks to install bellow packages with `Homebrew`:

- wireguard-tools
- qrencode